### PR TITLE
Hotfix/anchor link

### DIFF
--- a/GBJSTK.js
+++ b/GBJSTK.js
@@ -683,8 +683,16 @@ var gb = (function() {
 
 	function getItem(key, callback) {
 		var cb = "function(value) {\
-			var obj = JSON.parse(value);\
 			var _f = " + callback + ";\
+			if (!value) {\
+				_f();\
+				return;\
+			}\
+			var obj = JSON.parse(value);\
+			if (!obj) {\
+				_f();\
+				return;\
+			}\
 			_f(obj['value']);\
         }";
 		var s = gbCallbackToString(cb);

--- a/GBJSTK.js
+++ b/GBJSTK.js
@@ -328,17 +328,21 @@ var gb = (function() {
 			gbDevMode = false;
 
 			// Intercept clicks on links in order to call the corresponding method
-			var gbCustomLinks = document.getElementsByTagName("a");
-			for(var z = 0; z < gbCustomLinks.length; z++) {
-				var gbCustomLink = gbCustomLinks[z];
-				if (!gbCustomLink.protocol.startsWith('javascript')) {
-					gbCustomLink.onclick = function(e){
-						e.preventDefault();
-						parent.postMessage({url: this.getAttribute("href")}, '*');
-						return false;
-					};
+			window.addEventListener("click", function(evt) {
+				const target = evt.target.closest("a");
+				if (target) {
+					const href = target.getAttribute("href") || "";
+					const isAnchor = href.startsWith("#");
+					const isJS = target.protocol.startsWith("javascript");
+					if (!isAnchor && !isJS) {
+						target.onclick = function(e) {
+							e.preventDefault();
+							parent.postMessage({url: href}, "*");
+							return false;
+						}
+					}
 				}
-			}
+			});
 		}
 
 		/* Function : gbWebsiteSetData


### PR DESCRIPTION
This fix is about anchor link that doesn't behavior like expected inside a plugin.

Anchor links are now fetched on every click on the page. The onclick event is set on each link and send the message back to the iframe parent's.